### PR TITLE
Bugfix/include live build

### DIFF
--- a/app/controllers/front_end_builds/apps_controller.rb
+++ b/app/controllers/front_end_builds/apps_controller.rb
@@ -5,13 +5,20 @@ module FrontEndBuilds
     before_action :set_app , :only => [:show, :destroy, :update]
 
     def index
-      apps = App.includes(:recent_builds)
-      respond_with_json({
+      apps = App.includes(:recent_builds, :live_build)
+
+      recent_builds = apps.map(&:recent_builds)
+      live_builds = apps.map(&:live_build)
+      builds = recent_builds
+               .push(live_builds)
+               .flat_map(&:to_a)
+               .reject(&:nil?)
+               .uniq
+
+      respond_with_json(
         apps: apps.map(&:serialize),
-        builds: apps.map(&:recent_builds)
-                  .flat_map(&:to_a)
-                  .map(&:serialize)
-      })
+        builds: builds.map(&:serialize)
+      )
     end
 
     def show

--- a/app/controllers/front_end_builds/apps_controller.rb
+++ b/app/controllers/front_end_builds/apps_controller.rb
@@ -12,7 +12,7 @@ module FrontEndBuilds
       builds = recent_builds
                .push(live_builds)
                .flat_map(&:to_a)
-               .reject(&:nil?)
+               .compact
                .uniq
 
       respond_with_json(

--- a/spec/controllers/front_end_builds/apps_controller_spec.rb
+++ b/spec/controllers/front_end_builds/apps_controller_spec.rb
@@ -18,6 +18,18 @@ module FrontEndBuilds
       end
     end
 
+    describe "many builds" do
+      let(:many_build_app) { create(:front_end_builds_app, name: 'many builds') }
+      let!(:live_build) { create(:front_end_builds_build, :live, :fetched, app: many_build_app)}
+      let!(:many_builds) { create_list(:front_end_builds_build, 100, app: many_build_app) }
+
+      it "should include the live build even it's not most recent" do
+        get :index, format: :json
+        
+        expect(json['builds'].map { | a | a['id'] }).to include(live_build.id)
+      end
+    end
+
     describe 'show' do
       it "should find the requested app" do
         get :show, params: { id: app.id }, format: :json

--- a/spec/models/front_end_builds/app_spec.rb
+++ b/spec/models/front_end_builds/app_spec.rb
@@ -10,11 +10,11 @@ module FrontEndBuilds
 
     describe '#recent_builds' do
       it 'should only show the 10 most recent builds' do
-        create_list(:front_end_builds_build, 11, {
+        create_list(:front_end_builds_build, 51, {
           app: app
         })
 
-        expect(app.recent_builds.size).to eq(10)
+        expect(app.recent_builds.size).to eq(50)
       end
 
       it 'should order the builds with the most recent at top' do


### PR DESCRIPTION
Currently when you have lots of builds, it's possible for the live build to not be contained in 'recent builds'.  This PR ensures that we always include the live build in the payload.

This fixes the issue in the main admin index page.