### PR TITLE
Specifies a specific response content type for the index action

### DIFF
--- a/app/controllers/front_end_builds/admin_controller.rb
+++ b/app/controllers/front_end_builds/admin_controller.rb
@@ -15,7 +15,7 @@ module FrontEndBuilds
       html = html.sub('BASEURL/', baseURL)
       html = html.sub("baseURL: ''", "baseURL: '#{baseURL}'")
 
-      render plain: html
+      render body: html, content_type: 'text/html'
     end
 
   end


### PR DESCRIPTION
`render plain:` is using a content type of `text/plain` in Rails 6, and `text/html` in Rails 5. This smoothes things over so they both use a `text/html` response.